### PR TITLE
chore: jenkinsx-app-quickstart2 to 0.0.5

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.114
 - name: jenkinsx-app-quickstart2
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.4
+  version: 0.0.5


### PR DESCRIPTION
chore: Promote jenkinsx-app-quickstart2 to version 0.0.5